### PR TITLE
CTS256A-AL2 v0.1.0-alpha

### DIFF
--- a/CTS256A-AL2/CTS256A_AL2.h
+++ b/CTS256A-AL2/CTS256A_AL2.h
@@ -49,7 +49,7 @@ class CTS256A_AL2_Data_InOut
 public:
 	CTS256A_AL2_Data_InOut( TMS7000CPU &cpu, std::istream &istr, std::ostream &ostr )
 		: cpu_( cpu ), istr_( istr ), ostr_( ostr ), bport_( 0 ), initctr_( 6 ), irq3ctr_( 0 ), eof_( false )
-		, debug_( false ), verbose_( false ), echo_( false ), noOK_( false ), mode_( 'T' ), debugctr_( DEBUG_CTR_RELOAD )
+		, debug_( false ), debug_rules_( false ), verbose_( false ), echo_( false ), noOK_( false ), mode_( 'T' ), debugctr_( DEBUG_CTR_RELOAD )
 	{
 		memset( ram_, 0, 0x800 );
 	}
@@ -83,6 +83,8 @@ public:
 
 	uint getOption( uchar option );
 
+	void debug_rule();
+
 private:
 	uchar					bport_;
 	TMS7000CPU				&cpu_;
@@ -95,11 +97,13 @@ private:
 	uint					eofctr_;
 	bool					eof_;
 	bool					debug_;
+	bool					debug_rules_;
 	bool					verbose_;
 	bool					echo_;
 	bool					textMode_;
 	bool					noOK_;
 	char					mode_;
+	char					initial_;
 };
 
 

--- a/CTS256A-AL2/ConsoleDebugger.cpp
+++ b/CTS256A-AL2/ConsoleDebugger.cpp
@@ -87,13 +87,14 @@ static void showHelp( Console_I &con )
 		"\n X = Exec until RET"
 		"\n S = Show next lines of disassembly"
 		"\n R = Show reg names"
-		"\n M = Registers indirect dump"
+//		"\n M = Registers indirect dump"
 		"\n H = Hex dump current page"
 		"\n ; = Hex dump next page"
 		"\n - = Hex dump prev page"
 		"\n . = Hex dump 16 pages forward"
 		"\n _ = Hex dump 16 pages backward"
 		"\n F = Font set"
+		"\n Sh-F10 to exit"
 		);
 }
 

--- a/CTS256A-AL2/main.cpp
+++ b/CTS256A-AL2/main.cpp
@@ -26,7 +26,7 @@
 #include "stdafx.h"
 
 #define NAME	"CTS256A-AL2(tm) Emulator"
-#define VERSION	"v0.0.6-alpha"
+#define VERSION	"v0.1.0-alpha"
 
 #include "ConIOConsole.h"
 #include "CTS256A_AL2.h"
@@ -50,6 +50,7 @@ void help()
 		" -b        Select binary output (range 40..7F)\n"
 		" -e        Echo input text\n"
 		" -v        Verbose mode\n"
+		" -r        Rules debugging mode\n"
 		" -d        Debug mode\n"
 		" -n        Suppress 'O.K.'\n"
 		" --        Stop parsing options\n"
@@ -62,7 +63,7 @@ void help()
 int _tmain(int argc, _TCHAR* argv[])
 {
 	char mode = 'T';
-	bool echo = false, debug = false, verbose = false, noOK = false, opts = true;
+	bool echo = false, debug = false, debug_rules = false, verbose = false, noOK = false, opts = true;
 
 	std::istream *pistr = &std::cin;
 	std::ostream *postr = &std::cout;
@@ -114,6 +115,9 @@ int _tmain(int argc, _TCHAR* argv[])
 			case 'D': // Debug
 				debug = 1;
 				break;
+			case 'R': // Debug CTS rules
+				debug_rules = 1;
+				break;
 			case 'V': // Verbose
 				verbose = 1;
 				break;
@@ -148,6 +152,7 @@ int _tmain(int argc, _TCHAR* argv[])
 	system.setOption( 'D', debug );
 	system.setOption( 'E', echo );
 	system.setOption( 'V', verbose );
+	system.setOption( 'R', debug_rules );
 	system.setOption( 'N', noOK );
 	system.setOption( 'M', mode );
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ Version 0.0.6-alpha.
 A pre-release of the executables (Win32-x86) can be found under 'Releases'.
 
 
+## History
+
+### CTS256A-AL2 v0.1.0-alpha
+- added rules debugging mode `-r`;
+- use 'external' RAM for buffers;
+- fixed an issue with the idle loops handling;
+- convert the input chars to upper case to circumvent a defect in the ROM related to the lower case chars handling.
+
+### v0.0.6-alpha
+- converted code-to-speech rules to text using macros to encode them;
+- splitted the source code into separate parts.
+
+
 ## Description
 
 Two emulators in this project:


### PR DESCRIPTION
- added rules debugging mode `-r`;
- use 'external' RAM for buffers;
- fixed an issue with the idle loops handling;
- convert the input chars to upper case to circumvent a defect in the ROM related to the lower case chars handling.